### PR TITLE
Since the order in which we receive the allowed address pair doesn't …

### DIFF
--- a/tempest/api/network/test_allowed_address_pair.py
+++ b/tempest/api/network/test_allowed_address_pair.py
@@ -90,7 +90,8 @@ class AllowedAddressPairTestJSON(base.BaseNetworkTest):
         body = self.ports_client.update_port(
             port_id, allowed_address_pairs=allowed_address_pairs)
         allowed_address_pair = body['port']['allowed_address_pairs']
-        self.assertEqual(allowed_address_pair, allowed_address_pairs)
+        self.assertEqual(sorted(allowed_address_pair),
+                         sorted(allowed_address_pairs))
 
     @test.idempotent_id('9599b337-272c-47fd-b3cf-509414414ac4')
     def test_update_port_with_address_pair(self):


### PR DESCRIPTION
…matter we should remove that dependency. One of the proposed solution to this is sorting allowed_pair attribute dict and then asserting them
